### PR TITLE
Make hlpr_gazebo depend on package, not metapackage

### DIFF
--- a/hlpr_gazebo/launch/state_publishers.launch
+++ b/hlpr_gazebo/launch/state_publishers.launch
@@ -5,6 +5,7 @@
   <node pkg="robot_state_publisher" type="robot_state_publisher" name="robot_state_publisher">
     <param name="publish_frequency" type="double" value="100.0" />
     <param name="tf_prefix" type="string" value="" />
+    <param name="use_tf_static" value="false"/>
   </node>
 
   <!-- Fake Calibration -->

--- a/hlpr_gazebo/launch/vector.launch
+++ b/hlpr_gazebo/launch/vector.launch
@@ -3,6 +3,7 @@
     <arg name="limited" default="false"/>
     <arg name="paused" default="false"/>
     <arg name="gui" default="true"/>
+    <arg name="gazebo_verbose" default="false" />
     <arg name="world" default="worlds/empty.world" />
     <arg name="room" default="$(find hlpr_gazebo)/launch/simple_room.launch" />
     <arg name="robot_description" default="$(find vector_description)/launch/vector_upload.launch"/>
@@ -20,6 +21,7 @@
         <arg name="world_name" default="$(arg world)"/>
         <arg name="paused" value="$(arg paused)"/>
         <arg name="gui" value="$(arg gui)"/>
+        <arg name="verbose" value="$(arg gazebo_verbose)"/>
     </include>
 
     <!-- simple world -->

--- a/hlpr_gazebo/launch/vector_controllers.launch
+++ b/hlpr_gazebo/launch/vector_controllers.launch
@@ -37,7 +37,8 @@
     <!-- Setup initial simulation positions -->
     <node name="r_sim_setup" pkg="hlpr_gazebo" type="body_part_setup.py" output="screen"
             args="vector/right_arm">
-        <!--param name="init_position" value="0, 3.14, 3.14, 0, 0, 0"/ ZERO CONFIG (straight out)-->
+        <!-- ZERO CONFIG (straight out) -->
+        <!-- <param name="init_position" value="0, 3.14, 3.14, 0, 0, 0"/> --> 
         <param name="init_position" value="-1.92, 1.50, 0.53, -2.50, -2.91, 0.72"/>
     </node>
 

--- a/hlpr_gazebo/package.xml
+++ b/hlpr_gazebo/package.xml
@@ -17,7 +17,7 @@
   <license>BSD</license>
   
   <buildtool_depend>catkin</buildtool_depend>
-  <run_depend>gazebo_ros_pkgs</run_depend>
+  <run_depend>gazebo_plugins</run_depend>
   <run_depend>gazebo_ros</run_depend>
   <run_depend>gazebo_ros_control</run_depend>
   <run_depend>ros_controllers</run_depend>

--- a/hlpr_gazebo/package.xml
+++ b/hlpr_gazebo/package.xml
@@ -20,7 +20,6 @@
   <run_depend>gazebo_plugins</run_depend>
   <run_depend>gazebo_ros</run_depend>
   <run_depend>gazebo_ros_control</run_depend>
-  <run_depend>ros_controllers</run_depend>
   <run_depend>joint_state_controller</run_depend>
   <run_depend>joint_trajectory_controller</run_depend>
   <run_depend>robot_state_publisher</run_depend>

--- a/hlpr_gazebo/scripts/body_part_setup.py
+++ b/hlpr_gazebo/scripts/body_part_setup.py
@@ -45,11 +45,10 @@ class JointTrajectorySetup():
 
 
     def run(self):
-        while self.joint_names is None:
-            print "Waiting for joint state information from %s/state topic" %self.controller
-            rospy.sleep(2)
-        print "Received joint state information. Sending %s to default position (rads)" % self.controller
-        print self.position
+        while self.joint_names is None and not rospy.is_shutdown():
+            rospy.loginfo_throttle(5, "Waiting for joint state information from %s/state topic" %self.controller)
+            rospy.sleep(0.1)
+        rospy.loginfo("Received joint state information. Sending %s to default position (rads)" % self.controller + str(self.position))
 
         cmd_msg = self.send_cmd_msg()
         self.goal_pub.publish(cmd_msg)
@@ -68,4 +67,9 @@ if __name__=='__main__':
 
 
     JTT = JointTrajectorySetup(controller=controller, position=position)
-    JTT.run()
+    try:
+        JTT.run()
+    except rospy.exceptions.ROSInterruptException as e:
+        rospy.loginfo("JTT for " + controller + "was interrupted before receiving joint information")
+    else:
+        pass

--- a/hlpr_gazebo/src/vector_control_interface.py
+++ b/hlpr_gazebo/src/vector_control_interface.py
@@ -131,15 +131,15 @@ class VectorControllerConverter():
         self.gripper_cmd[self.RIGHT_KEY] = None
 
         # Initialize components for moveit IK service
-        rospy.logwarn("Waiting for MoveIt! for 10 seconds...")
+        rospy.loginfo("Waiting for MoveIt! for 10 seconds...")
         try:
             rospy.wait_for_service('compute_ik', timeout=10.0)  # Wait for 10 seconds and assumes we don't want IK
             self.compute_ik = rospy.ServiceProxy('compute_ik', GetPositionIK)
         except rospy.ROSException, e:
-            rospy.logwarn("MoveIt was not loaded and arm teleop will not be available")
+            rospy.loginfo("MoveIt was not loaded and arm teleop will not be available")
             self.compute_ik = None 
         else: 
-            rospy.logwarn("MoveIt detected")
+            rospy.loginfo("MoveIt detected")
             self.eef_sub = rospy.Subscriber('/vector/right_arm/cartesian_vel_cmd', JacoCartesianVelocityCmd, self.EEFCallback, queue_size=1)
 
         rospy.loginfo("Done Init")


### PR DESCRIPTION
Allows compatibility with `catkin build` by depending on true ROS package, not metapackage. See https://github.com/catkin/catkin_tools/issues/370 for details.