### PR TITLE
Force robot_state_publisher to use Indigo behavior

### DIFF
--- a/hlpr_gazebo/launch/state_publishers.launch
+++ b/hlpr_gazebo/launch/state_publishers.launch
@@ -5,6 +5,7 @@
   <node pkg="robot_state_publisher" type="robot_state_publisher" name="robot_state_publisher">
     <param name="publish_frequency" type="double" value="100.0" />
     <param name="tf_prefix" type="string" value="" />
+    <param name="use_tf_static" value="false"/>
   </node>
 
   <!-- Fake Calibration -->


### PR DESCRIPTION
the use_static_tf flag defaults to "true" in Kinetic. This is different
from the Indigo behavior and causes issues when running the robot in simulation
(the TF trees are not properly connected).

This PR forces use of the default Indigo behavior, even for other ROS versions like Kinetic.